### PR TITLE
Introduce CONTRIBUTOR-RECOGNITION.md to Define Badge and Recognition Framework

### DIFF
--- a/docs/governance/CONTRIBUTOR-RECOGNITION.md
+++ b/docs/governance/CONTRIBUTOR-RECOGNITION.md
@@ -1,0 +1,72 @@
+
+# CONTRIBUTOR-RECOGNITION.md
+
+> 🏅 This document defines how contributors to the NI Open-Source Program are recognized through public badges, acknowledgments, and long-term reputation signals.  
+> It is intended to motivate and acknowledge individuals based on transparent, measurable contributions to the program’s success.
+
+---
+
+## §1. Purpose of Contributor Recognition
+
+Contributor recognition serves to:
+- Acknowledge sustained leadership and initiative support
+- Encourage visible, measurable contributions
+- Provide incentives aligned with recertification, resume building, and community trust
+- Signal readiness for additional responsibility (e.g., SteerCo, Maintainer)
+
+---
+
+## §2. Recognition Principles
+
+- Recognition must be **public, traceable, and earned**.
+- Recognition is **not tied to employment** or company affiliation.
+- All recognition must be **anchored in GitHub activity**, unless otherwise noted.
+- The system avoids complex tiers unless justified by future program scaling.
+
+---
+
+## §3. Types of Recognition
+
+| Badge | Criteria | Tracked Through |
+|-------|----------|-----------------|
+| 🛠 **Maintainer** | Actively reviews PRs, merges code, maintains repo health for >1 month | GitHub roles + PR history |
+| 🧭 **SteerCo Member** | Publicly listed in accepted SteerCo with 2-hour/week engagement | GitHub discussions + onboarding form |
+| 💬 **Top Contributor** | Authored accepted PRs, test reports, or meaningful discussions across 3+ issues | GitHub issue history |
+| 🧪 **Test Coordinator** | Regularly verifies IP through manual test reports and community coordination | GitHub test issues + Projects |
+| 🧱 **Infra Builder** | Creates GitHub Actions, CI pipelines, or contribution tooling adopted across repos | GitHub commit history |
+| 🎓 **Certified Contributor** *(Planned)* | Integrated with NI recertification process via GitHub-linked tracking | TBD |
+
+---
+
+## §4. How Badges Are Issued
+
+- Badges are **awarded manually** by the Program Manager, based on observable GitHub activity.
+- Badge issuance is **documented publicly** in a repo discussion thread (e.g., `open-source/discussions/recognition`).
+- No self-nomination is required—community and SteerCo members may propose nominees.
+
+---
+
+## §5. Public Acknowledgment Channels
+
+- Recognized contributors will be listed on:
+  - The program’s GitHub site (README/CONTRIBUTORS)
+  - NI Connect slides (where applicable)
+  - NI’s internal and external newsletters (if opted-in)
+- Recognition status may influence SteerCo invitations and roadmap access
+
+---
+
+## §6. Future Automation Goals
+
+As the program scales, we plan to:
+- Automate badge tracking via GitHub Actions and metadata (e.g., label counting, PR authorship)
+- Link recertification points to GitHub handles (in collaboration with the Certification team)
+- Provide personalized dashboards for long-term contributor visibility
+
+---
+
+## §7. Revision History
+
+| Date       | Summary                              |
+|------------|--------------------------------------|
+| 2025-05-22 | Initial version drafted after committee feedback |


### PR DESCRIPTION

# Introduce `CONTRIBUTOR-RECOGNITION.md` to Define Badge and Recognition Framework

This PR introduces a new governance document, `CONTRIBUTOR-RECOGNITION.md`, to define how contributors to the NI Open-Source Program are publicly acknowledged. This draft reflects input from the 2025-05-22 open source core team meeting and builds on existing community engagement structures.

## 🔍 Summary of Key Content:
- Establishes core **principles of recognition**: public, earned, GitHub-visible.
- Introduces six badge categories including:
  - Maintainer
  - SteerCo Member
  - Top Contributor
  - Test Coordinator
  - Infra Builder
  - Certified Contributor *(planned)*
- Ties recognition to **measurable GitHub activity** (e.g., PRs, issues, reviews).
- Formalizes a **manual badge issuance process** documented in public GitHub discussions.
- Lists **public channels** where contributor status may be acknowledged (e.g., GitHub READMEs, NI Connect slides).

## 📌 Why This Matters:
- Fulfills community requests for transparent acknowledgment of leadership and effort.
- Reduces ambiguity around contributor roles outside SteerCo.
- Lays foundation for integrating GitHub activity with certification incentives.

## 🔗 Related Governance Context:
- `STEERCO-GUIDELINES.md`: Outlines recognition as part of SteerCo participation.
- `PRIORITY-SCORE.md`: Ties Interest and Community Engagement to visible contributor signals.

## ✅ Follow-up Actions:
- Open a public GitHub discussion thread (e.g., `discussions/recognition`) to track nominations.
- Begin badge issuance manually via Program Manager discretion.
- Define GitHub Actions workflow for automation in future phase.
