### PR TITLE
Add `ENGAGEMENT-GUIDE.md` to Define GitHub Usage and Contributor Expectations

### DIFF
--- a/docs/governance/ENGAGEMENT-GUIDE.md
+++ b/docs/governance/ENGAGEMENT-GUIDE.md
@@ -1,0 +1,80 @@
+
+# ENGAGEMENT-GUIDE.md
+
+> 💬 This guide outlines how contributors to the NI Open-Source Program should engage via GitHub. It defines how to report issues, propose changes, participate in discussions, and track contributions in a way that aligns with the program’s governance and scoring model.
+
+---
+
+## §1. General Engagement Philosophy
+
+The NI Open-Source Program is designed to:
+- Empower contributors to take initiative
+- Minimize approval bottlenecks
+- Encourage clarity and structure without rigidity
+
+Contributions are tracked directly via GitHub and recognized via badges, SteerCo membership, or certification points. All engagement should be public and auditable.
+
+---
+
+## §2. Where to Post
+
+| Use Case | Use This | Notes |
+|----------|----------|-------|
+| ❗ Report a bug or technical issue | **GitHub Issue** | Must be actionable, reproducible, and scoped. |
+| 💡 Propose a new feature or improvement | **GitHub Issue** | Clearly label as `enhancement`. Include use case. |
+| 🧪 Report results of a manual test | **GitHub Issue** | Use the `Test Result` template if available. |
+| ❓ Ask a general question or raise uncertainty | **GitHub Discussion** | For open-ended input, community dialogue. |
+| 🔁 Propose a PR | **GitHub Pull Request** | Include context: why, how, and how it was tested. |
+| 🗣️ Share long-term ideas or meta-program suggestions | **Program Discussion Thread** | Use `open-source/discussions` repo. |
+
+---
+
+## §3. Contributor Best Practices
+
+- Always use labels (e.g., `bug`, `enhancement`, `test result`, `documentation`)
+- Reference related issues in PRs using `Fixes #123` or `Related to #456`
+- Keep titles specific and meaningful
+- For test reports, include:
+  - **Test ID** (if defined)
+  - **Platform/Version**
+  - **Expected vs. Actual Behavior**
+  - **Outcome** (Pass/Fail/Blocked)
+
+---
+
+## §4. Manual Testing and Structured Test Reports
+
+To improve the reliability of open-source IP, the program uses GitHub Issues to track manual testing by volunteers.
+
+When submitting a test report:
+- Use the `Test Result` issue template if available
+- Be clear if the test was exploratory or for a known bug
+- Tag `test-coordinator` if assigned
+- Link to the relevant milestone or GitHub Project board if applicable
+
+---
+
+## §5. Engagement and Recognition
+
+Consistent GitHub activity is the **main signal** used to award:
+- Badges (see `CONTRIBUTOR-RECOGNITION.md`)
+- SteerCo invitations
+- Certification points (for eligible LabVIEW contributors)
+
+Visible GitHub contributions help the Program Manager and NI leadership prioritize effort and evaluate interest across the ecosystem.
+
+---
+
+## §6. Reporting Inappropriate Use or Abuse
+
+If you experience harassment, inappropriate conduct, or off-topic behavior:
+- Use GitHub’s reporting tools or email `sergio.velderrain@emerson.com`
+- All contributors are expected to follow the [Open Source Community Code Of Conduct] (In progress)
+
+---
+
+## §7. Revision History
+
+| Date       | Summary                              |
+|------------|--------------------------------------|
+| 2025-05-22 | Initial version based on contributor workflow analysis |


### PR DESCRIPTION

# Add `ENGAGEMENT-GUIDE.md` to Define GitHub Usage and Contributor Expectations

This PR introduces a new document, `ENGAGEMENT-GUIDE.md`, to formalize how contributors should engage across GitHub repositories managed under the NI Open-Source Program.

## 🔍 Summary of Key Content:
- Defines **where to post** depending on contributor intent (e.g., Issues vs. Discussions).
- Describes best practices for:
  - Filing reproducible bugs
  - Labeling test results
  - Submitting PRs with traceability
- Establishes workflow norms for **manual testing** and **test result issue reporting**.
- Highlights the relationship between GitHub engagement and:
  - Recognition (via badges)
  - Priority scoring (via community interest)
  - Recertification eligibility (planned integration)

## 📌 Why This Matters:
- Reduces ambiguity for new contributors.
- Helps scale quality and participation by documenting clear engagement paths.
- Aligns contributor behavior with NI's scoring, evaluation, and recognition systems.

## 🔗 Related Governance Files:
- `CONTRIBUTOR-RECOGNITION.md`: Engagement is the primary input to contributor badges.
- `PRIORITY-SCORE.md`: “Interest” is one of four inputs to priority scoring, measured via GitHub.
- `STEERCO-GUIDELINES.md`: Reinforces expectation of 2 hours/week of GitHub-visible leadership.

## ✅ Follow-up Actions:
- Link this guide from the main program README and CONTRIBUTING templates.
- Monitor community usage to refine templates and automate label triggers.
