### PR TITLE
Declare THREAD-v2025.5-KNOWLEDGE-CORPUS.md for GPT Interpretation

### DIFF
--- a/docs/governance/THREAD-v2025.5-KNOWLEDGE-CORPUS.md
+++ b/docs/governance/THREAD-v2025.5-KNOWLEDGE-CORPUS.md
@@ -1,0 +1,59 @@
+# THREAD-v2025.5-KNOWLEDGE-CORPUS.md
+
+**Status:** Declared  
+**Version:** v2025.5  
+**Owner:** Program Manager  
+**Effective:** Upon merge to `main`  
+**Repository:** [ni/open-source](https://github.com/ni/open-source)
+
+---
+
+## 📘 Purpose
+
+This THREAD declares the authoritative **Knowledge Corpus** for the NI LabVIEW Open Source Program. Each listed document serves as a version-controlled source of truth and is classified with a semantic role to enable structured interpretation by governance-aware agents.
+
+---
+
+## 🧠 Ontological Document Roles
+
+| Semantic Role         | Description |
+|------------------------|-------------|
+| **Program Charter**      | High-level program overview, repository lifecycle, scope |
+| **Strategic Policy**     | Defines prioritization, stakeholder authority, and operational logic |
+| **Recognition Logic**    | Governs public recognition and contributor tracking |
+| **Engagement Norms**     | Standards for issues, pull requests, discussions, and meetings |
+| **Governance Memory**    | Time-stamped changelog of governance evolution |
+| **Role Schema**          | Defines actor responsibilities and file-level ownership |
+
+---
+
+## 📚 Declared Knowledge Documents
+
+| Document | Path | Role |
+|----------|------|------|
+| `PROGRAM-GUIDE.md` | [`./docs/governance/PROGRAM-GUIDE.md`](https://github.com/ni/open-source/blob/main/docs/governance/PROGRAM-GUIDE.md) | Program Charter |
+| `PRIORITY-SCORE.md` | [`./docs/governance/PRIORITY-SCORE.md`](https://github.com/ni/open-source/blob/main/docs/governance/PRIORITY-SCORE.md) | Strategic Policy |
+| `STEERCO-GUIDELINES.md` | [`./docs/governance/STEERCO-GUIDELINES.md`](https://github.com/ni/open-source/blob/main/docs/governance/STEERCO-GUIDELINES.md) | Strategic Policy |
+| `CONTRIBUTOR-RECOGNITION.md` | [`./docs/governance/CONTRIBUTOR-RECOGNITION.md`](https://github.com/ni/open-source/blob/main/docs/governance/CONTRIBUTOR-RECOGNITION.md) | Recognition Logic |
+| `RECOGNITION-TAG-MAP.md` | [`./docs/governance/RECOGNITION-TAG-MAP.md`](https://github.com/ni/open-source/blob/main/docs/governance/RECOGNITION-TAG-MAP.md) | Recognition Logic |
+| `ENGAGEMENT-GUIDE.md` | [`./docs/governance/ENGAGEMENT-GUIDE.md`](https://github.com/ni/open-source/blob/main/docs/governance/ENGAGEMENT-GUIDE.md) | Engagement Norms |
+| `MEETING-POLICY.md` | [`./docs/governance/MEETING-POLICY.md`](https://github.com/ni/open-source/blob/main/docs/governance/MEETING-POLICY.md) | Engagement Norms |
+| `GOVERNANCE-CHANGELOG.md` | [`./docs/governance/GOVERNANCE-CHANGELOG.md`](https://github.com/ni/open-source/blob/main/docs/governance/GOVERNANCE-CHANGELOG.md) | Governance Memory |
+| `ROLE-MAP.md` | [`./docs/governance/ROLE-MAP.md`](https://github.com/ni/open-source/blob/main/docs/governance/ROLE-MAP.md) | Role Schema |
+
+---
+
+## 🛡️ Interpretation Rules
+
+- **Only declared documents** may be interpreted by runtime agents
+- Every document must be assigned a semantic role
+- Interpretation requires this THREAD to be cited explicitly
+- Contracts may further constrain per-document behavior
+
+---
+
+## 🔧 Governance Extension
+
+- New documents must be added by amending this THREAD
+- New semantic roles require STEERCO review and declaration
+- All changes to this THREAD must be versioned


### PR DESCRIPTION
This pull request declares `THREAD-v2025.5-KNOWLEDGE-CORPUS.md`, formalizing the Knowledge Corpus for the NI LabVIEW Open Source Program under governance version `v2025.5`.

📘 This THREAD defines:
- The semantic roles of all declared governance documents
- The interpretation boundaries for GPTs
- The centralized source of truth for runtime behavioral guidance

🔐 Tagged in release: [`v2025.5.1`](https://github.com/ni/open-source/releases/tag/v2025.5.1)

#THREAD-v2025.5-KNOWLEDGE-CORPUS  
#ROLE:ProgramManager  
#GPT-INTERPRETABLE
