### PR TITLE
Declare THREAD-v2025.5-CONTRIBUTING.md to Govern Contributor Participation

### DIFF
--- a/docs/governance/THREAD-v2025.5-CONTRIBUTING.md
+++ b/docs/governance/THREAD-v2025.5-CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# THREAD-v2025.5-CONTRIBUTING.md
+
+**Status:** Declared  
+**Version:** v2025.5  
+**Owner:** Program Manager  
+**Effective:** Upon merge to `main`  
+**Repository:** [ni/open-source](https://github.com/ni/open-source)
+
+---
+
+## 📘 Purpose
+
+This THREAD governs the interpretation of `CONTRIBUTING.md`, which outlines the onboarding path, participation rules, and recertification eligibility for contributors to repositories under the NI Open-Source Program.
+
+This THREAD ensures:
+- Consistent interpretation of contribution requirements
+- GPT-safe recognition of activity-to-value relationships
+- Boundaries on who can revise contributor expectations
+
+---
+
+## 📄 Scope of Governance
+
+| File             | Semantic Role        | Interpretation Bound |
+|------------------|----------------------|----------------------|
+| `CONTRIBUTING.md` | Procedural Onboarding | THREAD-v2025.5-CONTRIBUTING.md |
+
+---
+
+## 👥 Role Enforcement
+
+- **Program Manager**:
+  - Maintains authority over recertification rules and contributor eligibility
+  - Validates GitHub activity and SteerCo inputs
+- **STEERCO**:
+  - May size and review issues but may not revise contribution models
+- **Contributors**:
+  - May suggest improvements to CONTRIBUTING.md via PRs but cannot override approval paths
+
+---
+
+## 🤖 GPT Runtime Constraints
+
+- GPTs may not interpret contribution value, onboarding, or badge eligibility outside the logic in this THREAD
+- GPTs must always reference this THREAD when interpreting participation templates, recertification rules, or activity logic
+- All assistant references to contribution flow must preserve structure and embed full formatting unless `#manual-edit` is used
+
+---
+
+## 📎 File Expectations
+
+The file `CONTRIBUTING.md` must:
+- Define GitHub-based activity categories (e.g., issue claiming, PR templates)
+- Reference official onboarding and sizing models
+- List review expectations and role references clearly
+
+---
+
+## 🔧 Governance Extension
+
+- Changes to contributor scoring or onboarding rules must amend this THREAD
+- Any assistant-based file insertion must follow the assistant enforcement rules in `CONTRIBUTING.md`


### PR DESCRIPTION
This THREAD governs the interpretation of `CONTRIBUTING.md` under runtime version `v2025.5`. It formalizes contributor onboarding rules, recertification eligibility, and GPT-safe activity logic.

📘 This THREAD:
- Binds `CONTRIBUTING.md` to the v2025.5 procedural governance model
- Clarifies who may revise contribution expectations and how
- Restricts GPT interpretation to declared rules and structures

🔐 Enables GPT-safe participation guidance and structural enforcement

#THREAD-v2025.5-CONTRIBUTING  
#ROLE:ProgramManager  
#GPT-INTERPRETABLE
