### PR TITLE
Declare THREAD-v2025.5-ROLE-ENFORCEMENT.md to Govern File Ownership

### DIFF
--- a/docs/governance/THREAD-v2025.5-ROLE-ENFORCEMENT.md
+++ b/docs/governance/THREAD-v2025.5-ROLE-ENFORCEMENT.md
@@ -1,0 +1,69 @@
+# THREAD-v2025.5-ROLE-ENFORCEMENT.md
+
+**Status:** Declared  
+**Version:** v2025.5  
+**Owner:** Program Manager  
+**Effective:** Upon merge to `main`  
+**Repository:** [ni/open-source](https://github.com/ni/open-source)
+
+---
+
+## 📘 Purpose
+
+This THREAD governs the interpretation and authority implications of `ROLE-MAP.md`, which defines the ownership and approval scope of all declared governance roles within the NI Open-Source Program.
+
+This THREAD ensures:
+- GPTs and contributors interpret file ownership and decision boundaries consistently
+- No role is misrepresented or granted excessive power by default
+- Thread and contract authority chains are traceable to declared roles
+
+---
+
+## 📄 Scope of Governance
+
+| File         | Semantic Role   | Interpretation Bound                  |
+|--------------|------------------|----------------------------------------|
+| `ROLE-MAP.md` | Role Schema       | THREAD-v2025.5-ROLE-ENFORCEMENT.md     |
+
+---
+
+## 👥 Role Enforcement Logic
+
+- **Program Manager**:
+  - Owns and maintains `ROLE-MAP.md`, badge criteria, scoring logic, and file authority schema
+  - Has override power for role declarations and structural corrections
+
+- **STEERCO**:
+  - May propose changes but cannot revise the ROLE-MAP directly
+  - Participates in contributor evaluation but cannot reassign file ownership
+
+- **Core Team** *(planned)*:
+  - May review or override file access decisions where specified
+
+- **Maintainers and Certification Teams** *(planned)*:
+  - Refer to `ROLE-MAP.md` to understand what they can and cannot do
+  - Cannot unilaterally change governance logic
+
+---
+
+## 🤖 GPT Runtime Constraints
+
+- GPTs must validate any claim of file ownership against the current `ROLE-MAP.md`
+- GPTs must treat unauthorized edits, comments, or merges as violations unless sanctioned in this THREAD
+- Runtime authority assertions must always cite this THREAD
+
+---
+
+## 📎 File Expectations
+
+The file `ROLE-MAP.md` must:
+- Map every governance role to file authority
+- List who can approve what types of changes
+- Be updated only through versioned THREADs
+
+---
+
+## 🔧 Governance Extension
+
+- New roles and authority changes must be added through new THREADs or versioned amendments
+- Runtime enforcement behavior is frozen to the logic in this THREAD until superseded


### PR DESCRIPTION
This THREAD binds and governs `ROLE-MAP.md` under runtime version `v2025.5`. It enforces interpretation of role authority, file ownership, and GPT runtime constraints.

📘 This THREAD:
- Declares `ROLE-MAP.md` as a governance-critical role schema
- Limits GPT and contributor behavior based on declared role permissions
- Prevents hallucinated authority or unauthorized editing logic

🔐 Enables GPT-safe file governance enforcement

#THREAD-v2025.5-ROLE-ENFORCEMENT  
#ROLE:ProgramManager  
#GPT-INTERPRETABLE
